### PR TITLE
Add support for QPrivateSignal parameters

### DIFF
--- a/include/rxqt_signal.hpp
+++ b/include/rxqt_signal.hpp
@@ -82,15 +82,41 @@ struct from_signal<R, Q, A0>
     }
 };
 
+template <class Q, class T>
+struct is_private_signal : std::false_type {};
+
+template <class Q>
+struct is_private_signal<Q, typename Q::QPrivateSignal> : std::true_type {};
+
+template <class R, class Q, class T, class U>
+struct construct_signal_type;
+
+template <class R, class Q, class T, std::size_t... Is>
+struct construct_signal_type<R, Q, T, std::index_sequence<Is...>>
+{
+    using type = from_signal<R, Q, typename std::tuple_element<Is, T>::type...>;
+};
+
+template <class R, class Q, class ...Args>
+struct get_signal_factory
+{
+    using as_tuple = std::tuple<Args...>;
+    static constexpr bool has_private_signal =
+        is_private_signal<Q, typename std::tuple_element<sizeof...(Args) - 1, as_tuple>::type>::value;
+    static constexpr size_t arg_count = has_private_signal ? sizeof...(Args) - 1 : sizeof...(Args);
+    using type = typename construct_signal_type<R, Q, as_tuple, std::make_index_sequence<arg_count>>::type;
+};
+
 } // detail
 
 } // signal
 
 template <class R, class Q, class ...Args>
-rxcpp::observable<typename signal::detail::from_signal<R, Q, Args...>::value_type>
+rxcpp::observable<typename signal::detail::get_signal_factory<R, Q, Args...>::type::value_type>
 from_signal(const Q* qobject, R(Q::*signal)(Args...))
 {
-    return signal::detail::from_signal<R, Q, Args...>::create(qobject, signal);
+    using signal_factory = typename signal::detail::get_signal_factory<R, Q, Args...>::type;
+    return typename signal_factory::create(qobject, reinterpret_cast<typename signal_factory::signal_type>(signal));
 }
 
 } // qtrx


### PR DESCRIPTION
If you're interested... I've added some code to cope with signals that have a `QPrivateSignal` parameter added to ensure that they can't be emitted by anything but the originating object - the one that bit me was `QFileSystemWatcher::fileChanged`.

The code uses template metaprogramming to remove a `QPrivateSignal` parameter from a signal's signature if it's the final parameter in the signal's parameter list, and to generate an observable using the stripped signature.

The code uses some C++14 features (`std::index_sequence`). I've tested with Visual Studio 2015 Update 3, but not with any other compilers, although I would have thought gcc and clang would be fine with it.