### PR TITLE
Add base class signal support

### DIFF
--- a/include/rxqt_signal.hpp
+++ b/include/rxqt_signal.hpp
@@ -117,12 +117,12 @@ struct get_signal_factory<R, Q>
 
 } // signal
 
-template <class R, class Q, class ...Args>
-rxcpp::observable<typename signal::detail::get_signal_factory<R, Q, Args...>::type::value_type>
-from_signal(const Q* qobject, R(Q::*signal)(Args...))
+template <class P, class R, class Q, class ...Args>
+std::enable_if_t<std::is_base_of<Q, P>::value, rxcpp::observable<typename signal::detail::get_signal_factory<R, Q, Args...>::type::value_type>>
+from_signal(const P* qobject, R(Q::*signal)(Args...))
 {
     using signal_factory = typename signal::detail::get_signal_factory<R, Q, Args...>::type;
-    return signal_factory::create(qobject, reinterpret_cast<typename signal_factory::signal_type>(signal));
+    return signal_factory::create(static_cast<const Q*>(qobject), reinterpret_cast<typename signal_factory::signal_type>(signal));
 }
 
 } // qtrx


### PR DESCRIPTION
This PR adds support for signals declared on base classes, but emitted on derived classes. An example -

````C++
   QPushButton* pushButton = new QPushButton(this);
   rxqt::from_signal(pushButton, &QPushButton::clicked).subscribe([this](bool) {
      QMessageBox::information(this, "Button pressed", "Button pressed");
   });
````

This will not currently compile without a type cast on the widget pointer - `rxqt::from_signal((QAbstractButton*)pushButton, &QPushButton::clicked)` - to unify the types used, allowing template argument deduction to succeed.

To do this, a new template parameter, `P`, has been added to `from_signal`, which is constrained (using SFINAE through `std::enable_if_t`) to be `Q` or something derived from `Q`. This changes the signature of `from_signal` to this:

````C++
template <class P, class R, class Q, class ...Args>
std::enable_if_t<std::is_base_of<Q, P>::value,
                 rxcpp::observable<typename signal::detail::get_signal_factory<R, Q, Args...>::type::value_type>>
from_signal(const P* qobject, R(Q::*signal)(Args...))
{
   ...
}
````

which separates the widget and signal types sufficiently, allowing template argument deduction to succeed.

I've tested this with g++ 5.4.0 on Ubuntu 16.04 (`gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.4)`) as well as Visual Studio 2015 Update 3 (`Microsoft (R) C/C++ Optimizing Compiler Version 19.00.24213.1 for x86`).