### PR TITLE
Add OS X and Windows CI support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,17 @@
+image:
+  - Visual Studio 2015
+
+install:
+  - git clone https://github.com/Reactive-Extensions/RxCpp.git RxCpp
+
+before_build:
+  - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
+  - set PATH=C:\Qt\5.9\msvc2015\bin;%PATH%
+
+build_script:
+  - cd test
+  - qmake test.pro
+  - nmake
+
+test_script:
+  - .\Release\rxtest.exe

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,34 @@
 language: cpp
-sudo: required
-compiler:
-  - gcc
-before_install:
-  - lsb_release -a
-  - sudo apt-add-repository -y ppa:ubuntu-toolchain-r/test
-  - sudo apt-add-repository -y ppa:beineri/opt-qt562
-  - sudo apt-get -qq update
-  - sudo apt-get -qq install g++-5 libc6-i386 qt56tools qt56base
-  - export CXX="g++-5"
-  - export CC="gcc-5"
+
+matrix:
+  include:
+    - os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - sourceline: 'ppa:beineri/opt-qt562'
+          packages:
+            - g++-5
+            - libc6-i386
+            - qt56tools
+            - qt56base
+      before_install:
+        - export CC=gcc-5
+        - export CXX=g++-5
+        - export PATH="/opt/qt56/bin/:${PATH}"
+        - qt56-env.sh
+    - os: osx
+      compiler: clang
+      before_install:
+        - brew install qt
+        - export PATH="/usr/local/opt/qt/bin/:${PATH}"
+
 install:
   - git clone https://github.com/Reactive-Extensions/RxCpp.git RxCpp
 script:
-  - QTDIR="/opt/qt56"
-  - PATH="$QTDIR/bin:$PATH"
-  - qt56-env.sh
   - cd test
   - qmake test.pro
-  - make CXX="g++-5" CC="gcc-5" all
+  - make CXX="${CXX}" CC="${CC}" all
   - ./rxtest

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-[![Build Status](https://travis-ci.org/tetsurom/rxqt.svg?branch=master)](https://travis-ci.org/tetsurom/rxqt)
+[![Linux and OS X Build Status](https://travis-ci.org/tetsurom/rxqt.svg?branch=master)](https://travis-ci.org/tetsurom/rxqt)
+
+[![Windows Build Status](https://ci.appveyor.com/api/projects/status/github/tetsurom/rxqt?svg=true)](https://ci.appveyor.com/api/projects/status/github/tetsurom/rxqt)
+
 
 # RxQt
 The Reactive Extensions for Qt.

--- a/test/signaltest.cpp
+++ b/test/signaltest.cpp
@@ -59,7 +59,7 @@ private slots:
         bool completed = false;
         {
             TestObservable subject;
-            rxqt::from_signal(&subject, &TestObservable::signal_binary).subscribe([&](const std::tuple<int, const QString&>& t) {
+            rxqt::from_signal(&subject, &TestObservable::signal_binary).subscribe([&](const std::tuple<int, const QString>& t) {
                 QVERIFY(std::get<0>(t) == 1);
                 QVERIFY(std::get<1>(t) == "string");
                 called = true;
@@ -108,7 +108,7 @@ private slots:
         bool completed = false;
         {
             TestObservable subject;
-            rxqt::from_signal(&subject, &TestObservable::signal_private_binary).subscribe([&](const std::tuple<int, const QString&>& t) {
+            rxqt::from_signal(&subject, &TestObservable::signal_private_binary).subscribe([&](const std::tuple<int, const QString>& t) {
                 QVERIFY(std::get<0>(t) == 1);
                 QVERIFY(std::get<1>(t) == "string");
                 called = true;


### PR DESCRIPTION
There are a number of changes here:

1. Added an OS X build to the `.travis.yml` file (and tidied up the Linux build)
2. Added Windows CI support using Appveyor through .appveyor.yml
3. Modified the `Readme.md` badges to match (note that you'll have to [sign up to Appveyor](https://ci.appveyor.com/projects) & add the rxqt repository there for the Appveyor one to work)
1. Fixed an issue in the test exposed by the OS X build