### PR TITLE
Add Qt wrapper around RxCpp run loop to enable timed events such as debounce

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,27 @@ observable<QEvent*> rxqt::from_event(QObject* object, QEvent::Type type);
 
 Convert Qt event to a observable.
 
+## run_loop
+
+Provide an interface between the Qt event loop and RxCpp's run loop scheduler. This enables use of timed RxCpp operators (such as `delay` and `debounce`) with RxQt.
+
+Using `run_loop` requires an object of type `run_loop` to be live while the Qt event loop is active. This can be achieved most simply through use of a local variable defined after the Qt application object has been instantiated in `main`, or wherever the applicaiton object is instantiated. The example below gives an example of appropriate instantiation of the `run_loop`, together with a main window class of `MainWindow`:
+
+```cpp
+int main(int argc, char* argv[])
+{
+   QApplication a(argc, argv);
+   MainWindow w;
+   rxqt::run_loop rxqt_run_loop;
+   w.show();
+   return a.exec();
+}
+```
+
 # Contribution
 
 Issues or Pull Requests are welcomed :)
 
 # Requirement
 
-* [RxCpp](https://github.com/Reactive-Extensions/RxCpp)
+* [RxCpp](https://github.com/Reactive-Extensions/RxCpp) (minimum of v4.0 for use of `rxqt::run_loop`)

--- a/include/rxqt.hpp
+++ b/include/rxqt.hpp
@@ -6,5 +6,6 @@
 #include <rxqt_signal.hpp>
 #include <rxqt_event.hpp>
 #include <rxqt_util.hpp>
+#include <rxqt_run_loop.hpp>
 
 #endif // RXQT_H

--- a/include/rxqt_run_loop.hpp
+++ b/include/rxqt_run_loop.hpp
@@ -1,0 +1,70 @@
+#pragma once
+
+#ifndef RXQT_RUN_LOOP_HPP
+
+#include <rxcpp/rx.hpp>
+#include <QTimer>
+
+namespace rxqt {
+
+namespace run_loop {
+
+class RunLoop
+{
+public:
+   RunLoop(QObject *parent = Q_NULLPTR) : timer(parent)
+   {
+      // Give the RxCpp run loop a a function to let us schedule a wakeup in order to dispatch run loop events
+      rxcpp_run_loop.set_notify_earlier_wakeup([&](std::chrono::steady_clock::time_point when)
+      {
+         // Tell the timer to wake-up at `when` if its not already waking up earlier
+         const auto ms_till_task = ms_until(when);
+         if (!timer.isActive() || ms_till_task.count() < timer.remainingTime())
+         {
+            timer.start(ms_till_task.count());
+         }
+      });
+      timer.setSingleShot(true);
+      timer.setTimerType(Qt::PreciseTimer);
+      // When the timer expires, we'll flush the run loop
+      timer.connect(&timer, &QTimer::timeout, [&]() { onEventScheduled(); });
+   }
+
+private:
+   // Flush the RxCpp run loop
+   void onEventScheduled()
+   {
+      // Dispatch outstanding RxCpp events
+      while (!rxcpp_run_loop.empty() && rxcpp_run_loop.peek().when < rxcpp_run_loop.now())
+      {
+         rxcpp_run_loop.dispatch();
+      }
+      // If there are outstanding events, set the timer to wakeup for the first one
+      if (!rxcpp_run_loop.empty())
+      {
+         const auto time_till_next_event = ms_until(rxcpp_run_loop.peek().when);
+         timer.start(static_cast<int>(time_till_next_event.count()));
+      }
+   }
+   // Calculate milliseconds from now until `when`
+   std::chrono::milliseconds ms_until(rxcpp::schedulers::run_loop::clock_type::time_point const& when) const
+   {
+      return ceil<std::chrono::milliseconds>(when - rxcpp_run_loop.now());
+   }
+   // Round the specified duration to the smallest number of `To` ticks that's not less than `duration`
+   template <class To, class Rep, class Period>
+   static inline To ceil(const std::chrono::duration<Rep, Period>& duration)
+   {
+      const auto as_To = std::chrono::duration_cast<To>(duration);
+      return (as_To < duration) ? (as_To + To{1}) : as_To;
+   }
+   rxcpp::schedulers::run_loop rxcpp_run_loop;
+   QTimer timer;
+};
+
+} // namespace run_loop
+
+
+} // namespace rxqt
+
+#endif // RXQT_RUN_LOOP_HPP

--- a/include/rxqt_run_loop.hpp
+++ b/include/rxqt_run_loop.hpp
@@ -7,12 +7,10 @@
 
 namespace rxqt {
 
-namespace run_loop {
-
-class RunLoop
+class run_loop
 {
-public:
-   RunLoop(QObject *parent = Q_NULLPTR) : timer(parent)
+ public:
+   run_loop(QObject *parent = Q_NULLPTR) : timer(parent)
    {
       // Give the RxCpp run loop a a function to let us schedule a wakeup in order to dispatch run loop events
       rxcpp_run_loop.set_notify_earlier_wakeup([&](std::chrono::steady_clock::time_point when)
@@ -61,9 +59,6 @@ private:
    rxcpp::schedulers::run_loop rxcpp_run_loop;
    QTimer timer;
 };
-
-} // namespace run_loop
-
 
 } // namespace rxqt
 


### PR DESCRIPTION
This pull-request provides code interfacing [RxCpp](https://github.com/Reactive-Extensions/RxCpp)'s run loop to Qt's event loop, allowing Qt GUI events to be processed and dispatched, but then calling into the RxCpp run-loop when timed RxCpp events are due. Without this, RxCpp cannot process timed RxCpp operators like delay or debounce.

The most significant use of this for me has been to allow me to use the debounce operator within GUI programs, which I've used (for example) to coalesce Qt events (such as model item selection changes) before triggering potentially expensive processing.

To use this within a Qt program requires very little change - you just need to have a run loop object present throughout execution of the Qt program. The variable needs to be created after your `QApplication` object, but before the Qt event loop is started, as shown below.

``` c++
#include <QApplication>
#include <rxqt.hpp>

#include "mainwindow.h"

int main(int argc, char* argv[])
{
   QApplication a(argc, argv);
   MainWindow w;
   rxqt::run_loop rl;
   w.show();
   return a.exec();
}
```

This pull-request is dependent on [this commit](https://github.com/Reactive-Extensions/RxCpp/commit/ad101cf093028f874a5d882967bdb4ccb8032eb8) of [RxCpp](https://github.com/Reactive-Extensions/RxCpp) (included in v4.0.0 of [RxCpp](https://github.com/Reactive-Extensions/RxCpp)), which adds hooks to the [RxCpp](https://github.com/Reactive-Extensions/RxCpp) run-loop implementation that can be exploited to interface [RxCpp](https://github.com/Reactive-Extensions/RxCpp) to an external event loop such as (in this case) the Qt event loop.