### PR TITLE
includes: use relative includes

### DIFF
--- a/include/rxqt.hpp
+++ b/include/rxqt.hpp
@@ -3,10 +3,10 @@
 #ifndef RXQT_H
 #define RXQT_H
 
-#include <rxqt_event.hpp>
-#include <rxqt_run_loop.hpp>
-#include <rxqt_run_loop_thread.hpp>
-#include <rxqt_signal.hpp>
-#include <rxqt_util.hpp>
+#include "rxqt_event.hpp"
+#include "rxqt_run_loop.hpp"
+#include "rxqt_run_loop_thread.hpp"
+#include "rxqt_signal.hpp"
+#include "rxqt_util.hpp"
 
 #endif // RXQT_H

--- a/include/rxqt_run_loop_thread.hpp
+++ b/include/rxqt_run_loop_thread.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #ifndef RXQT_RUN_LOOP_THREAD_HPP
 
-#include <rxqt_run_loop.hpp>
+#include "rxqt_run_loop.hpp"
 
 namespace rxqt {
 class RunLoopThread : public QThread {


### PR DESCRIPTION
This allows rxqt to be placed into a subdirectory and included via
`<rxqt/…>` paths.